### PR TITLE
Adding gap

### DIFF
--- a/contracts/TurnupSharesV4.sol
+++ b/contracts/TurnupSharesV4.sol
@@ -632,4 +632,10 @@ contract TurnupSharesV4 is Initializable, OwnableUpgradeable {
       revert UnableToSendFunds();
     }
   }
+
+  // @dev This empty reserved space is put in place to allow future versions to add new
+  // variables without shifting down storage in the inheritance chain.
+  // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+
+  uint256[50] private __gap;
 }


### PR DESCRIPTION
We do not plan to use V4 as a base contract for V5, but a __gap there cannot be bad